### PR TITLE
Fix parse connection URL with empty query params

### DIFF
--- a/app/src/main/java/app/android/outlinevpntv/data/remote/ParseUrlOutline.kt
+++ b/app/src/main/java/app/android/outlinevpntv/data/remote/ParseUrlOutline.kt
@@ -80,7 +80,7 @@ interface ParseUrlOutline {
 
             val queryParams = groups[4].split("&").associate { q ->
                 q.split("=").let {
-                    it[0] to it.getOrElse(1) { "" }
+                    it[0] to Uri.decode(it.getOrElse(1) { "" })
                 }
             }
             val serverName = groups[5]

--- a/app/src/main/java/app/android/outlinevpntv/data/remote/ParseUrlOutline.kt
+++ b/app/src/main/java/app/android/outlinevpntv/data/remote/ParseUrlOutline.kt
@@ -77,8 +77,12 @@ interface ParseUrlOutline {
 
             val host = groups[2]
             val port = groups[3].toInt()
-            val queryParams =
-                groups[4].split("&").associate { q -> q.split("=").let { it[0] to it[1] } }
+
+            val queryParams = groups[4].split("&").associate { q ->
+                q.split("=").let {
+                    it[0] to it.getOrElse(1) { "" }
+                }
+            }
             val serverName = groups[5]
 
             return ShadowSocksInfo(method, password, host, port, queryParams["prefix"])


### PR DESCRIPTION
Fix `IndexOutOfBoundsException` with empty query params

Example connection URL that doesn't work: ss://Y2hhY2hhMjAtaWV0Zi1wb2x5MTMwNTpycVdQNlF6MWQ2MUFQc2Rsb1BXWUlH@be-1.web-of-russia.org:23382#Belgium

